### PR TITLE
Ejecutor codigo simple base

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       retries: 10
     command: --default-authentication-plugin=mysql_native_password
     networks:
-      - gensoft-network
+      - none
   
   user-management-service:
     build: ./user-management-service
@@ -124,6 +124,11 @@ services:
 
   sandbox:
     build: ./sandbox
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
     ports:
       - "8002:8002"
     depends_on:
@@ -139,7 +144,8 @@ services:
     volumes:
       - ./sandbox:/app 
     networks:
-      - gensoft-network
+      - none
+    pids_limit: 100
   
   sandbox-test:
     build:
@@ -156,7 +162,7 @@ services:
     volumes:
       - ./sandbox:/app 
     networks:
-      - gensoft-network
+      - none
 
   content-management-service:
     build: ./content-management-service
@@ -251,3 +257,6 @@ volumes:
 networks:
   gensoft-network:
     driver: bridge
+  none:
+    driver: bridge
+    internal: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       retries: 10
     command: --default-authentication-plugin=mysql_native_password
     networks:
-      - none
+      - gensoft-network
   
   user-management-service:
     build: ./user-management-service
@@ -144,7 +144,7 @@ services:
     volumes:
       - ./sandbox:/app 
     networks:
-      - none
+      - gensoft-network
     pids_limit: 100
   
   sandbox-test:
@@ -162,7 +162,7 @@ services:
     volumes:
       - ./sandbox:/app 
     networks:
-      - none
+      - gensoft-network
 
   content-management-service:
     build: ./content-management-service
@@ -257,6 +257,3 @@ volumes:
 networks:
   gensoft-network:
     driver: bridge
-  none:
-    driver: bridge
-    internal: true

--- a/sandbox/.gitignore
+++ b/sandbox/.gitignore
@@ -16,3 +16,5 @@ debug.log
 
 migrations/
 alembic.ini
+
+temp_script.py

--- a/sandbox/app/core/executor.py
+++ b/sandbox/app/core/executor.py
@@ -1,12 +1,34 @@
 import subprocess
+import tempfile
+import os
 
 def run_code(code: str):
-    # Save the code to a temporary file
     with open("temp_script.py", "w") as f:
         f.write(code)
-
-    # Run the code using subprocess
     result = subprocess.run(["python", "temp_script.py"], capture_output=True, text=True, timeout=3)
 
-    # Return the output and error messages
     return result.stdout, result.stderr
+
+def execute_code(code: str, call: str):
+    full_code = code + f"\n\nprint({call})\n"
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".py") as temp_script:
+        temp_script.write(full_code.encode("utf-8"))
+        temp_script_path = temp_script.name
+
+    try:
+        result = subprocess.run(
+            ["python", temp_script_path],
+            capture_output=True,
+            text=True,
+            timeout=3
+        )
+    except subprocess.TimeoutExpired:
+        os.remove(temp_script_path)
+        return {"output": "", "error": "TimeOut: Code execution timed out"}
+    
+    os.remove(temp_script_path)
+    return {
+        "output": result.stdout,
+        "error": result.stderr.strip().split("\n")[-1] if result.stderr else ""
+    }

--- a/sandbox/app/core/executor.py
+++ b/sandbox/app/core/executor.py
@@ -1,0 +1,12 @@
+import subprocess
+
+def run_code(code: str):
+    # Save the code to a temporary file
+    with open("temp_script.py", "w") as f:
+        f.write(code)
+
+    # Run the code using subprocess
+    result = subprocess.run(["python", "temp_script.py"], capture_output=True, text=True, timeout=3)
+
+    # Return the output and error messages
+    return result.stdout, result.stderr

--- a/sandbox/app/main.py
+++ b/sandbox/app/main.py
@@ -6,6 +6,9 @@ app = FastAPI()
 class CodeInput(BaseModel):
     code: str
 
+class CodeInput2(CodeInput):
+    call: str
+
 @app.get("/")
 def root():
     return {"message": "Hi World from Sandbox!"}
@@ -14,3 +17,8 @@ def root():
 def run_python_code(payload: CodeInput):
     stdout, stderr = executor.run_code(payload.code)
     return {"output": stdout, "errors": stderr}
+
+@app.post("/execute")
+def execute_code(payload: CodeInput2):
+    result = executor.execute_code(payload.code, payload.call)
+    return result

--- a/sandbox/app/main.py
+++ b/sandbox/app/main.py
@@ -1,7 +1,16 @@
 from fastapi import FastAPI
-
+from pydantic import BaseModel
+from .core import executor
 app = FastAPI()
+
+class CodeInput(BaseModel):
+    code: str
 
 @app.get("/")
 def root():
-    return {"message": "Hi World"}
+    return {"message": "Hi World from Sandbox!"}
+
+@app.post("/run")
+def run_python_code(payload: CodeInput):
+    stdout, stderr = executor.run_code(payload.code)
+    return {"output": stdout, "errors": stderr}

--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,2 +1,9 @@
 fastapi
 uvicorn
+sqlalchemy
+pymysql
+pydantic
+cryptography
+httpx
+pytest
+pytest-asyncio

--- a/sandbox/tests/test_executor.py
+++ b/sandbox/tests/test_executor.py
@@ -1,0 +1,22 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_if_program():
+    code = "if (1>12):\n    print('hola')\nelse:\n  print('hola:c')"
+    response = client.post("/run", json={"code": code})
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["output"] == "hola:c\n"
+    assert response_data["errors"] == ""
+
+def test_error_program():
+    code = "if (1>12): print('hola') else: print('hola:c')"
+    response = client.post("/run", json={"code": code})
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["output"] == ""
+    assert "SyntaxError" in response_data["errors"]
+

--- a/sandbox/tests/test_executor.py
+++ b/sandbox/tests/test_executor.py
@@ -20,3 +20,38 @@ def test_error_program():
     assert response_data["output"] == ""
     assert "SyntaxError" in response_data["errors"]
 
+def test_with_call():
+    code = "def hi2():\n    print('hola')"
+    call = "5+5"
+    response = client.post("/execute", json={"code": code, "call": call})
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["output"] == "10\n"
+    assert response_data["error"] == ""
+
+def test_with_code_error():
+    code = "def hi():\n    return 3+3+j"
+    call = "hi()"
+    response = client.post("/execute", json={"code": code, "call": call})
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["output"] == ""
+    assert "NameError" in response_data["error"]
+
+def test_with_call_error():
+    code = "def hi():\n    return 3+3+5"
+    call = "hi(5)"
+    response = client.post("/execute", json={"code": code, "call": call})
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["output"] == ""
+    assert "TypeError" in response_data["error"]
+
+def test_withTimeout():
+    code = "import time\ntime.sleep(5)"
+    call = "5+5"
+    response = client.post("/execute", json={"code": code, "call": call})
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["output"] == ""
+    assert "TimeOut" in response_data["error"]


### PR DESCRIPTION
- Endpoint /execute para ejecutar codigo y llamada por separado
- Endpoint /run para ejecutar codigo directamente
- 6 pruebas unitarias para validar su funcionamiento, incluyendo timeout

NOTA: Podriamos usar cualquiera dependiendo si usaremos una "terminal" en el frontend, de todas formas /execute permite llamar a una funcion directamente sin usar un print() para conocer resultado.

RECOMENDACION: Eliminar las imagenes relacionadas a Sandbox y sus containers o ejecutar `docker compose up --build`